### PR TITLE
Fixed output issue when add -e with -V is specified, now show elapsed…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,3 +75,5 @@ AC_CONFIG_FILES([Makefile
                  src/Makefile])
 
 AC_OUTPUT
+AM_PROG_CC_C_O
+

--- a/src/fping.c
+++ b/src/fping.c
@@ -514,8 +514,8 @@ int main( int argc, char **argv )
         case 'v':
             printf( "%s: Version %s\n", argv[0], VERSION);
             printf( "%s: comments to %s\n", argv[0], EMAIL );
-            printf( "Forked from original. Source can be found in the csv branch at:\n" );
-            printf( "    https://github.com/NetworkEng/fping/tree/csv\n" );
+            printf( "Original can be found in forked in repo:\n" );
+            printf( "    https://github.com/rctorr/fping\n" );
             exit( 0 );
 
         case 'f': 
@@ -1637,7 +1637,12 @@ int wait_for_reply(long wait_time)
         if( verbose_flag || alive_flag || csv_flag )
         {
             if( csv_flag && !unreachable_flag ) {
-                printf("%s,alive\n", h->host);
+                printf("%s,alive", h->host);
+
+                if (elapsed_flag)
+                    printf(",%s ms", sprint_tm(this_reply));
+
+                printf("\n");
             }
             else if( !unreachable_flag ) {
                 printf("%s", h->host);


### PR DESCRIPTION
Hi!

If you use option -V, otehr options are ignored, then a fixed only for -e option for show elapsed time using some csv format.
Example:
$ fping -Vne host
host,alive,56 ms

greetings
